### PR TITLE
调整算子库编译安装流程

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,14 +33,14 @@ jobs:
     - name: configure xmake
       run: xmake f --cpu=true -cv
 
-    - name: Build with XMake
-      run: xmake
-
-    - name: Find and Set INFINI_ROOT
-      id: set_infini_root
+    - name: Set INFINI_ROOT
       run: |
-        export INFINI_ROOT=$GITHUB_WORKSPACE
+        export INFINI_ROOT=$GITHUB_WORKSPACE/.infini
+        mkdir -p $INFINI_ROOT
         echo "INFINI_ROOT=$INFINI_ROOT" >> $GITHUB_ENV
+
+    - name: Build with XMake
+      run: xmake build && xmake install
 
     - name: Run Python Tests
       run: |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ infiniopStatus_t infiniopDestroyTensorDescriptor(infiniopTensorDescriptor_t desc
 
 ## 一、使用说明
 
-### 配置
+### 1. 配置
 
 #### 查看当前配置
 
@@ -99,23 +99,27 @@ xmake f --nv-gpu=true --cuda=$CUDA_HOME -cv
 xmake f --cambricon-mlu=true -cv
 ```
 
-### 编译
+#### 配置 NPU
+
+````xmake
+xmake f --ascend-npu=true -cv
+````
+
+### 2. 编译安装
 
 ```xmake
-xmake
+xmake build && xmake install
 ```
 
-### 将编译好的算子库添加至环境变量 `INFINI_ROOT`
+### 3. 设置环境变量
 
-```bash
-export INFINI_ROOT=[PATH_TO_LIBRARY]
-```
+按输出提示设置 `INFINI_ROOT` 和 `LD_LIBRARY_PATH` 环境变量。
 
-### 运行算子测试
+### 4. 运行算子测试
 
 ```bash
 cd operatorspy/tests
-python operator_name.py
+python operator_name.py [--cpu | --cuda | --cambricon | --ascend]
 ```
 
 ## 二、开发说明

--- a/xmake.lua
+++ b/xmake.lua
@@ -246,12 +246,12 @@ target("infiniop")
         local YELLOW = '\27[1;33m'
         local NC = '\27[0m'  -- No Color
 
-        if os.getenv("INFINI_ROOT") == nil then
+        local infini_dir = os.getenv("INFINI_ROOT")
+        if infini_dir == nil then
             print(YELLOW .. "INFINI_ROOT not set, installation path default to ~/.infini".. NC)
             print(YELLOW .. "It is recommended to set INFINI_ROOT as an environment variable." .. NC)
-            os.setenv("INFINI_ROOT", os.getenv("HOME") .. "/.infini")
+            infini_dir = os.getenv("HOME") .. "/.infini"
         end
-        local infini_dir = os.getenv("INFINI_ROOT")
 
         if os.isdir(infini_dir) then
             print("INFINI_ROOT already exists, duplicated contents will be overwritten.")

--- a/xmake.lua
+++ b/xmake.lua
@@ -125,7 +125,7 @@ if has_config("cambricon-mlu") then
             table.insert(target:objectfiles(), objectfile)
         end)
 
-rule_end()
+    rule_end()
 
 
     target("cambricon-mlu")
@@ -179,7 +179,7 @@ if has_config("ascend-npu") then
             os.rm(builddir.. "/libascend_kernels.a")
             
         end)
-        rule_end()
+    rule_end()
 
     target("ascend-npu")
         -- Other configs
@@ -226,9 +226,6 @@ target("infiniop")
             get_config("mode")
         )
 
-        os.exec("mkdir -p $(projectdir)/lib/")
-        os.exec("cp " ..builddir.. "/libinfiniop.so $(projectdir)/lib/")
-        os.exec("cp -r $(projectdir)/include $(projectdir)/lib/")
         -- Define color codes
         local GREEN = '\27[0;32m'
         local YELLOW = '\27[1;33m'
@@ -244,6 +241,11 @@ target("infiniop")
     
     on_install(function (target)
         print("Installing libraries...")
+
+        local GREEN = '\27[0;32m'
+        local YELLOW = '\27[1;33m'
+        local NC = '\27[0m'  -- No Color
+
         if os.getenv("INFINI_ROOT") == nil then
             print(YELLOW .. "INFINI_ROOT not set, installation path default to ~/.infini".. NC)
             print(YELLOW .. "It is recommended to set INFINI_ROOT as an environment variable." .. NC)
@@ -256,11 +258,18 @@ target("infiniop")
         else
             os.mkdir(infini_dir)
         end
-        os.exec("cp -r " .. "$(projectdir)/lib " .. infini_dir)
 
-        local GREEN = '\27[0;32m'
-        local YELLOW = '\27[1;33m'
-        local NC = '\27[0m'  -- No Color
+        local builddir = string.format(
+            "%s/build/%s/%s/%s",
+            os.projectdir(),
+            get_config("plat"),
+            get_config("arch"),
+            get_config("mode")
+        )        
+        os.exec("mkdir -p " .. infini_dir .. "/lib")
+        os.exec("cp " ..builddir.. "/libinfiniop.so " .. infini_dir .. "/lib/")
+        os.exec("cp -r $(projectdir)/include " .. infini_dir .. "/include")        
+
         os.exec("echo -e '" .. GREEN .. "Installation completed successfully at " .. infini_dir .. NC .. "'")
         os.exec("echo -e '" .. YELLOW .. "To set the environment variables, you can run the following command:" .. NC .. "'")
         os.exec("echo -e '" .. YELLOW .. "export INFINI_ROOT=" .. infini_dir .. NC .. "'")


### PR DESCRIPTION
主要更新：
1. 修改安装文件夹结构，在 INFINI_ROOT 路径下建立 lib 和 include 两个文件夹，安装时将 .so 拷贝到 lib 文件夹中，头文件拷贝到 include 文件夹中；
2. 更新 README 使用说明（之前在本地编译过算子库的，建议将 ~/.infini 目录和项目目录下的 build/ 目录以及 lib/ 目录删除后，再按照新的 README 说明进行编译安装）。