### PR TITLE
python 测试中添加 TensorDescriptor 的 invalidate 接口，禁止 kernel 直接使用外部传入的形状信息指针。

### DIFF
--- a/operatorspy/liboperators.py
+++ b/operatorspy/liboperators.py
@@ -16,8 +16,13 @@ class TensorDescriptor(Structure):
         ("dt", DataLayout),
         ("ndim", c_uint64),
         ("shape", POINTER(c_uint64)),
-        ("pattern", POINTER(c_int64)),
+        ("strides", POINTER(c_int64)),
     ]
+
+    def invalidate(self):
+        for i in range(self.ndim):
+            self.shape[i] = 0
+            self.strides[i] = 0
 
 
 infiniopTensorDescriptor_t = ctypes.POINTER(TensorDescriptor)

--- a/operatorspy/tests/add.py
+++ b/operatorspy/tests/add.py
@@ -74,6 +74,12 @@ def test(
             b_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    c_tensor.descriptor.contents.invalidate()
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+
     check_error(
         lib.infiniopAdd(descriptor, c_tensor.data, a_tensor.data, b_tensor.data, None)
     )

--- a/operatorspy/tests/attention.py
+++ b/operatorspy/tests/attention.py
@@ -155,6 +155,14 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    out_tensor.descriptor.contents.invalidate()
+    q_tensor.descriptor.contents.invalidate()
+    k_tensor.descriptor.contents.invalidate()
+    v_tensor.descriptor.contents.invalidate()
+    k_cache_tensor.descriptor.contents.invalidate()
+    v_cache_tensor.descriptor.contents.invalidate()
+
     workspace_size = c_uint64(0)
     check_error(
         lib.infiniopGetAttentionWorkspaceSize(descriptor, ctypes.byref(workspace_size))
@@ -406,4 +414,4 @@ if __name__ == "__main__":
         test_bang(lib, test_cases)
     if not (args.cpu or args.cuda or args.bang):
         test_cpu(lib, test_cases)
-    print("Test passed!")
+    print("\033[92mTest passed!\033[0m")

--- a/operatorspy/tests/avg_pool.py
+++ b/operatorspy/tests/avg_pool.py
@@ -118,6 +118,10 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     workspaceSize = ctypes.c_uint64(0)
     check_error(
         lib.infiniopGetAvgPoolWorkspaceSize(descriptor, ctypes.byref(workspaceSize))

--- a/operatorspy/tests/causal_softmax.py
+++ b/operatorspy/tests/causal_softmax.py
@@ -58,6 +58,10 @@ def test(lib, handle, torch_device, x_shape, x_stride=None, x_dtype=torch.float1
             descriptor, ctypes.byref(workspace_size)
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+
     workspace = create_workspace(workspace_size.value, x.device)
     check_error(
         lib.infiniopCausalSoftmax(
@@ -149,4 +153,4 @@ if __name__ == "__main__":
         test_ascend(lib, test_cases)
     if not (args.cpu or args.cuda or args.bang or args.ascend):
         test_cpu(lib, test_cases)
-    print("Test passed!")
+    print("\033[92mTest passed!\033[0m")

--- a/operatorspy/tests/conv.py
+++ b/operatorspy/tests/conv.py
@@ -135,6 +135,12 @@ def test(
             len(pads),
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    w_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     workspaceSize = ctypes.c_uint64(0)
     check_error(
         lib.infiniopGetConvWorkspaceSize(descriptor, ctypes.byref(workspaceSize))

--- a/operatorspy/tests/expand.py
+++ b/operatorspy/tests/expand.py
@@ -87,6 +87,10 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     for i in range(NUM_PRERUN if PROFILE else 1):
         check_error(lib.infiniopExpand(descriptor, y_tensor.data, x_tensor.data, None))
     if PROFILE:

--- a/operatorspy/tests/gemm.py
+++ b/operatorspy/tests/gemm.py
@@ -112,6 +112,13 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+    if c_tensor is not None:
+        c_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     workspace_size = ctypes.c_uint64(0)
     check_error(
         lib.infiniopGetGEMMWorkspaceSize(

--- a/operatorspy/tests/global_avg_pool.py
+++ b/operatorspy/tests/global_avg_pool.py
@@ -80,6 +80,11 @@ def test(
             x_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     workspaceSize = ctypes.c_uint64(0)
     check_error(
         lib.infiniopGetGlobalAvgPoolWorkspaceSize(

--- a/operatorspy/tests/matmul.py
+++ b/operatorspy/tests/matmul.py
@@ -100,6 +100,11 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+    c_tensor.descriptor.contents.invalidate()
+
     workspace_size = c_uint64(0)
     check_error(
         lib.infiniopGetMatmulWorkspaceSize(descriptor, ctypes.byref(workspace_size))

--- a/operatorspy/tests/max_pool.py
+++ b/operatorspy/tests/max_pool.py
@@ -115,6 +115,10 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     workspaceSize = ctypes.c_uint64(0)
     check_error(
         lib.infiniopGetMaxPoolWorkspaceSize(descriptor, ctypes.byref(workspaceSize))

--- a/operatorspy/tests/mlp.py
+++ b/operatorspy/tests/mlp.py
@@ -111,6 +111,12 @@ def test(
         )
     )
 
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    y_tensor.descriptor.contents.invalidate()
+    x_tensor.descriptor.contents.invalidate()
+    w12_tensor.descriptor.contents.invalidate()
+    w3_tensor.descriptor.contents.invalidate()
+
     workspace_size = c_uint64(0)
     check_error(
         lib.infiniopGetMLPWorkspaceSize(descriptor, ctypes.byref(workspace_size))
@@ -307,4 +313,4 @@ if __name__ == "__main__":
         test_bang(lib, test_cases)
     if not (args.cpu or args.cuda or args.bang):
         test_cpu(lib, test_cases)
-    print("Test passed!")
+    print("\033[92mTest passed!\033[0m")

--- a/operatorspy/tests/random_sample.py
+++ b/operatorspy/tests/random_sample.py
@@ -88,24 +88,26 @@ def test(lib, handle, torch_device, voc, random_val, topp, topk, temperature, x_
         ans = random_sample(data.to("cpu"), random_val, topp, topk, voc, temperature, "cpu")
     else:
         ans = random_sample_0(data)
-    if(torch_device == 'mlu' or torch_device == 'npu'):
-        
+    if torch_device == "mlu" or torch_device == "npu":
         indices = torch.zeros([1], dtype = torch.int64).to(torch_device)
     else:
-        
         indices = torch.zeros([1], dtype = torch.uint64).to(torch_device)
     x_tensor = to_tensor(data, lib)
     indices_tensor = to_tensor(indices, lib)
     if(torch_device == 'mlu' or torch_device == 'npu'):
         indices_tensor.descriptor.contents.dt = U64 # treat int64 as uint64
-    
-    
+
     descriptor = infiniopRandomSampleDescriptor_t()
     check_error(
         lib.infiniopCreateRandomSampleDescriptor(
             handle, ctypes.byref(descriptor), indices_tensor.descriptor, x_tensor.descriptor
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    indices_tensor.descriptor.contents.invalidate()
+
     workspace_size = c_uint64(0)
     check_error(
         lib.infiniopGetRandomSampleWorkspaceSize(
@@ -158,7 +160,7 @@ def test_bang(lib, test_cases):
     for (voc, random_val, topp, topk, temperature) in test_cases:
         test(lib, handle, "mlu", voc, random_val, topp, topk, temperature)
     destroy_handle(lib, handle)
-    
+
 
 def test_ascend(lib, test_cases):
     import torch_npu
@@ -166,8 +168,7 @@ def test_ascend(lib, test_cases):
     handle = create_handle(lib, device)
     for (voc, random_val, topp, topk, temperature) in test_cases:
         test(lib, handle, "npu", voc, random_val, topp, topk, temperature)
-    destroy_handle(lib, handle) 
-    
+    destroy_handle(lib, handle)
 
 
 if __name__ == "__main__":

--- a/operatorspy/tests/random_sample.py
+++ b/operatorspy/tests/random_sample.py
@@ -88,14 +88,10 @@ def test(lib, handle, torch_device, voc, random_val, topp, topk, temperature, x_
         ans = random_sample(data.to("cpu"), random_val, topp, topk, voc, temperature, "cpu")
     else:
         ans = random_sample_0(data)
-    if torch_device == "mlu" or torch_device == "npu":
-        indices = torch.zeros([1], dtype = torch.int64).to(torch_device)
-    else:
-        indices = torch.zeros([1], dtype = torch.uint64).to(torch_device)
+    indices = torch.zeros([1], dtype=torch.int64).to(torch_device)
     x_tensor = to_tensor(data, lib)
     indices_tensor = to_tensor(indices, lib)
-    if(torch_device == 'mlu' or torch_device == 'npu'):
-        indices_tensor.descriptor.contents.dt = U64 # treat int64 as uint64
+    indices_tensor.descriptor.contents.dt = U64  # treat int64 as uint64
 
     descriptor = infiniopRandomSampleDescriptor_t()
     check_error(
@@ -134,7 +130,6 @@ def test(lib, handle, torch_device, voc, random_val, topp, topk, temperature, x_
 
     assert indices[0].type(ans.dtype) == ans or data[ans] == data[indices[0]]
     check_error(lib.infiniopDestroyRandomSampleDescriptor(descriptor))
-    print("Test passed!")
 
 def test_cpu(lib, test_cases):
     device = DeviceEnum.DEVICE_CPU

--- a/operatorspy/tests/rearrange.py
+++ b/operatorspy/tests/rearrange.py
@@ -56,11 +56,15 @@ def test(
             handle, ctypes.byref(descriptor), y_tensor.descriptor, x_tensor.descriptor
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     check_error(
         lib.infiniopRearrange(descriptor, y_tensor.data, x_tensor.data, None)
     )
     assert torch.allclose(x, y, atol=0, rtol=1e-3)
-    print("Test passed!")
     check_error(lib.infiniopDestroyRearrangeDescriptor(descriptor))
 
 
@@ -141,3 +145,4 @@ if __name__ == "__main__":
         test_bang(lib, test_cases)
     if args.ascend:
         test_ascend(lib, test_cases)
+    print("\033[92mTest passed!\033[0m")

--- a/operatorspy/tests/relu.py
+++ b/operatorspy/tests/relu.py
@@ -84,6 +84,11 @@ def test(
             x_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    x_tensor.descriptor.contents.invalidate()
+    y_tensor.descriptor.contents.invalidate()
+
     for i in range(NUM_PRERUN if PROFILE else 1):
         check_error(lib.infiniopRelu(descriptor, y_tensor.data, x_tensor.data, None))
     if PROFILE:

--- a/operatorspy/tests/swiglu.py
+++ b/operatorspy/tests/swiglu.py
@@ -74,6 +74,12 @@ def test_out_of_place(
             b_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+    c_tensor.descriptor.contents.invalidate()
+
     check_error(
         lib.infiniopSwiGLU(
             descriptor, c_tensor.data, a_tensor.data, b_tensor.data, None
@@ -120,6 +126,11 @@ def test_in_place1(
             b_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+
     check_error(
         lib.infiniopSwiGLU(
             descriptor, a_tensor.data, a_tensor.data, b_tensor.data, None
@@ -166,6 +177,11 @@ def test_in_place2(
             b_tensor.descriptor,
         )
     )
+
+    # Invalidate the shape and strides in the descriptor to prevent them from being directly used by the kernel
+    a_tensor.descriptor.contents.invalidate()
+    b_tensor.descriptor.contents.invalidate()
+
     check_error(
         lib.infiniopSwiGLU(
             descriptor, b_tensor.data, a_tensor.data, b_tensor.data, None
@@ -173,7 +189,6 @@ def test_in_place2(
     )
 
     assert torch.allclose(b, ans, atol=1e-4, rtol=1e-2)
-    print("in-place2 Test passed!")
 
     check_error(lib.infiniopDestroySwiGLUDescriptor(descriptor))
 
@@ -278,3 +293,4 @@ if __name__ == "__main__":
         test_bang(lib, test_cases)
     if args.ascend:
         test_ascend(lib, test_cases)
+    print("\033[92mTest passed!\033[0m")


### PR DESCRIPTION
1. python 测试中添加 TensorDescriptor 的 invalidate 接口，用来禁止 kernel 直接使用外部传入的形状信息指针，该接口需要在测试脚本中的 lib.infiniopCreate[Op]Descriptor 后立马调用所有已创建的 tensor descriptor 的 invalidate 函数，具体使用见 pr 里代码示例；
2. 规范所有测试脚本，统一在测试结尾输出 "Test passed" 并绿色高亮显示；
3. RandomSample 测试统一各平台都由 pytorch 生成 int64 类型的 indices，传给框架强制视为 uint64。