### PR TITLE
曙光：支持DCU推理

### DIFF
--- a/src/devices/cuda/common_cuda.h
+++ b/src/devices/cuda/common_cuda.h
@@ -1,7 +1,12 @@
 #ifndef __COMMON_CUDA_H__
 #define __COMMON_CUDA_H__
 
+#ifdef ENABLE_SUGON_DCU
+#define MAX_THREADS_PER_BLOCK 512
+#else
 #define MAX_THREADS_PER_BLOCK 1024
+#endif
+
 #define MAX_WARP_PER_BLOCK 32
 #define WARP_SIZE 32
 

--- a/src/ops/matmul/cuda/matmul_cuda.cu
+++ b/src/ops/matmul/cuda/matmul_cuda.cu
@@ -13,20 +13,38 @@ infiniopStatus_t matmul_cuda(MatmulCudaDescriptor_t desc, void *c, float beta, v
         std::swap(a, b);
     }
 
+    
+    
+#ifdef ENABLE_SUGON_DCU
+    float alpha_, beta_;
+#else
     Tdata alpha_, beta_;
+#endif
     cudaDataType a_type, b_type, c_type;
     cublasComputeType_t compute_type;
-
     if constexpr (std::is_same<Tdata, half>::value) {
+#ifdef ENABLE_SUGON_DCU
+        alpha_ = alpha;
+        beta_ = beta;
+#else
         alpha_ = __float2half(alpha);
         beta_ = __float2half(beta);
+#endif
         a_type = b_type = c_type = CUDA_R_16F;
+#ifdef ENABLE_SUGON_DCU
+        compute_type = CUBLAS_COMPUTE_32F;
+#else
         compute_type = CUBLAS_COMPUTE_16F;
+#endif
     } else {
         alpha_ = alpha;
         beta_ = beta;
         a_type = b_type = c_type = CUDA_R_32F;
+#ifdef ENABLE_SUGON_DCU
+        compute_type = CUBLAS_COMPUTE_32F;
+#else
         compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
+#endif
     }
 
     auto op_a = info.a_matrix.row_stride == 1 ? CUBLAS_OP_N : CUBLAS_OP_T;

--- a/src/ops/rearrange/cuda/rearrange.cu
+++ b/src/ops/rearrange/cuda/rearrange.cu
@@ -1,8 +1,9 @@
 #include "../../../devices/cuda/common_cuda.h"
 #include "rearrange.cuh"
+#include "../../utils.h"
 
 template<class Tmem>
-static __global__ void rearrange(
+static __launch_bounds__(MAX_THREADS_PER_BLOCK) __global__ void rearrange(
     void *__restrict__ dst,
     int const rsa,
     int const csa,
@@ -35,9 +36,9 @@ void rearrange_nv_gpu(RearrangeCudaDescriptor_t desc, void *y, void const *x, vo
         return;
     }
 
-    auto warps = 1024 / WARP_SIZE;
-    auto grid = dim3((c + warps - 1) / warps, r);
-    auto block = dim3(WARP_SIZE, (c + grid.x - 1) / grid.x);
+    auto warps = MAX_THREADS_PER_BLOCK / WARP_SIZE;
+    auto grid = dim3(ROUND_UP_DIV(c, warps), r);
+    auto block = dim3(WARP_SIZE, ROUND_UP_DIV(c, grid.x));
     dst_rs /= unit;
     dst_cs /= unit;
     src_rs /= unit;

--- a/src/ops/swiglu/cuda/swiglu.cu
+++ b/src/ops/swiglu/cuda/swiglu.cu
@@ -17,7 +17,7 @@ inline int gcd(int a, int b) {
 }
 
 template<class Tdata>
-static __global__ void swiglu(
+static __launch_bounds__(MAX_THREADS_PER_BLOCK) __global__ void swiglu(
     Tdata *__restrict__ c,
     int const stride_c,
     Tdata const *__restrict__ a,

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,6 +40,14 @@ option("ascend-npu")
     add_defines("ENABLE_ASCEND_NPU")
 option_end()
 
+option("sugon-dcu")
+    set_default(false)
+    set_showmenu(true)
+    set_description("Enable or disable Sugon DCU kernel")
+    add_defines("ENABLE_SUGON_DCU")
+    add_defines("ENABLE_NV_GPU")
+option_end()
+
 if is_mode("debug") then
     add_cxflags("-g -O0")
     add_defines("DEBUG_MODE")
@@ -66,9 +74,11 @@ if has_config("cpu") then
 
 end
 
-if has_config("nv-gpu") then
-
+if has_config("nv-gpu", "sugon-dcu") then
     add_defines("ENABLE_NV_GPU")
+    if has_config("sugon-dcu") then
+        add_defines("ENABLE_SUGON_DCU")
+    end
     local CUDA_ROOT = os.getenv("CUDA_ROOT") or os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH")
     local CUDNN_ROOT = os.getenv("CUDNN_ROOT") or os.getenv("CUDNN_HOME") or os.getenv("CUDNN_PATH")
     if CUDA_ROOT ~= nil then
@@ -212,6 +222,11 @@ if has_config("ascend-npu") then
     target_end()
 end
 
+
+toolchain("sugon-dcu-linker")
+    set_toolset("sh", "nvcc")
+toolchain_end()
+
 target("infiniop")
     set_kind("shared")
 
@@ -221,6 +236,21 @@ target("infiniop")
     if has_config("nv-gpu") then
         add_deps("nv-gpu")
     end
+    if has_config("sugon-dcu") then
+        local builddir = string.format(
+            "build/%s/%s/%s",
+            get_config("plat"),
+            get_config("arch"),
+            get_config("mode")
+        )
+        add_shflags("-s", "-shared", "-fPIC")
+        add_links("cublas", "cudnn", "cudadevrt", "cudart_static", "rt", "pthread", "dl")
+        -- Using -lnv-gpu will fail, manually link the target using full path
+        add_deps("nv-gpu", {inherit = false})
+        add_links(builddir.."/libnv-gpu.a")
+        set_toolchains("sugon-dcu-linker")
+    end
+
     if has_config("cambricon-mlu") then
         add_deps("cambricon-mlu")
     end


### PR DESCRIPTION
1. DCU单Block最大线程数512
2. kernel默认最大线程数256，需要用__launch_bounds__扩大到512
3. 目前的思路是xmake把DCU视为一种特殊的cuda，与nv cuda无法共存
4. DCU的cublas matmul暂不支持内部fp16计算，内部会将fp16转成fp32